### PR TITLE
Adds functional Network layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+
+# .DS_Store
+.DS_Store

--- a/SwileTest/SwileTest.xcodeproj/project.pbxproj
+++ b/SwileTest/SwileTest.xcodeproj/project.pbxproj
@@ -1,0 +1,700 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CA52B10029BBA0B4008345E0 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B0FF29BBA0B4008345E0 /* NetworkService.swift */; };
+		CA52B10329BBA176008345E0 /* NetworkServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B10229BBA176008345E0 /* NetworkServiceTests.swift */; };
+		CA52B10629BBA1B0008345E0 /* URLSessionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B10529BBA1B0008345E0 /* URLSessionMock.swift */; };
+		CA52B10829BBA20B008345E0 /* URLSessionDataTaskMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B10729BBA20B008345E0 /* URLSessionDataTaskMock.swift */; };
+		CA52B10D29BBB1AE008345E0 /* ServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B10C29BBB1AE008345E0 /* ServiceProtocol.swift */; };
+		CA52B11029BBB225008345E0 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B10F29BBB225008345E0 /* Service.swift */; };
+		CA52B11529BBCD4C008345E0 /* TransactionListResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B11429BBCD4C008345E0 /* TransactionListResponseModel.swift */; };
+		CA52B11829BBD541008345E0 /* TransactionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B11729BBD541008345E0 /* TransactionListViewModel.swift */; };
+		CA52B11A29BD59E3008345E0 /* Endpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B11929BD59E3008345E0 /* Endpoints.swift */; };
+		CA52B11C29BD5E5D008345E0 /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B11B29BD5E5D008345E0 /* Transaction.swift */; };
+		CA52B11E29BD5E75008345E0 /* TransactionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B11D29BD5E75008345E0 /* TransactionType.swift */; };
+		CA52B12029BD5E9E008345E0 /* TransactionIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B11F29BD5E9E008345E0 /* TransactionIcon.swift */; };
+		CA52B12229BD5EBA008345E0 /* TransactionAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B12129BD5EBA008345E0 /* TransactionAmount.swift */; };
+		CA52B12429BD5EF1008345E0 /* TransactionCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52B12329BD5EF1008345E0 /* TransactionCurrency.swift */; };
+		CADE074A29BB9D9900E1044A /* SwileTestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADE074929BB9D9900E1044A /* SwileTestApp.swift */; };
+		CADE074C29BB9D9900E1044A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADE074B29BB9D9900E1044A /* ContentView.swift */; };
+		CADE074E29BB9D9B00E1044A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CADE074D29BB9D9B00E1044A /* Assets.xcassets */; };
+		CADE075129BB9D9B00E1044A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CADE075029BB9D9B00E1044A /* Preview Assets.xcassets */; };
+		CADE075B29BB9D9B00E1044A /* SwileTestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADE075A29BB9D9B00E1044A /* SwileTestTests.swift */; };
+		CADE076529BB9D9B00E1044A /* SwileTestUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADE076429BB9D9B00E1044A /* SwileTestUITests.swift */; };
+		CADE076729BB9D9B00E1044A /* SwileTestUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADE076629BB9D9B00E1044A /* SwileTestUITestsLaunchTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		CADE075729BB9D9B00E1044A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CADE073E29BB9D9900E1044A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CADE074529BB9D9900E1044A;
+			remoteInfo = SwileTest;
+		};
+		CADE076129BB9D9B00E1044A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CADE073E29BB9D9900E1044A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CADE074529BB9D9900E1044A;
+			remoteInfo = SwileTest;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		CA52B0FF29BBA0B4008345E0 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
+		CA52B10229BBA176008345E0 /* NetworkServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServiceTests.swift; sourceTree = "<group>"; };
+		CA52B10529BBA1B0008345E0 /* URLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionMock.swift; sourceTree = "<group>"; };
+		CA52B10729BBA20B008345E0 /* URLSessionDataTaskMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionDataTaskMock.swift; sourceTree = "<group>"; };
+		CA52B10C29BBB1AE008345E0 /* ServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProtocol.swift; sourceTree = "<group>"; };
+		CA52B10F29BBB225008345E0 /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
+		CA52B11429BBCD4C008345E0 /* TransactionListResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionListResponseModel.swift; sourceTree = "<group>"; };
+		CA52B11729BBD541008345E0 /* TransactionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionListViewModel.swift; sourceTree = "<group>"; };
+		CA52B11929BD59E3008345E0 /* Endpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoints.swift; sourceTree = "<group>"; };
+		CA52B11B29BD5E5D008345E0 /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
+		CA52B11D29BD5E75008345E0 /* TransactionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionType.swift; sourceTree = "<group>"; };
+		CA52B11F29BD5E9E008345E0 /* TransactionIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionIcon.swift; sourceTree = "<group>"; };
+		CA52B12129BD5EBA008345E0 /* TransactionAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionAmount.swift; sourceTree = "<group>"; };
+		CA52B12329BD5EF1008345E0 /* TransactionCurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionCurrency.swift; sourceTree = "<group>"; };
+		CADE074629BB9D9900E1044A /* SwileTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwileTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		CADE074929BB9D9900E1044A /* SwileTestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwileTestApp.swift; sourceTree = "<group>"; };
+		CADE074B29BB9D9900E1044A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		CADE074D29BB9D9B00E1044A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		CADE075029BB9D9B00E1044A /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		CADE075629BB9D9B00E1044A /* SwileTestTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwileTestTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CADE075A29BB9D9B00E1044A /* SwileTestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwileTestTests.swift; sourceTree = "<group>"; };
+		CADE076029BB9D9B00E1044A /* SwileTestUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwileTestUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CADE076429BB9D9B00E1044A /* SwileTestUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwileTestUITests.swift; sourceTree = "<group>"; };
+		CADE076629BB9D9B00E1044A /* SwileTestUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwileTestUITestsLaunchTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CADE074329BB9D9900E1044A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CADE075329BB9D9B00E1044A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CADE075D29BB9D9B00E1044A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		CA52B0FE29BBA023008345E0 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				CA52B10F29BBB225008345E0 /* Service.swift */,
+				CA52B10C29BBB1AE008345E0 /* ServiceProtocol.swift */,
+				CA52B0FF29BBA0B4008345E0 /* NetworkService.swift */,
+				CA52B11929BD59E3008345E0 /* Endpoints.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		CA52B10129BBA156008345E0 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				CA52B10429BBA190008345E0 /* Mocks */,
+				CA52B10229BBA176008345E0 /* NetworkServiceTests.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		CA52B10429BBA190008345E0 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				CA52B10529BBA1B0008345E0 /* URLSessionMock.swift */,
+				CA52B10729BBA20B008345E0 /* URLSessionDataTaskMock.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		CA52B11129BBB24B008345E0 /* Features */ = {
+			isa = PBXGroup;
+			children = (
+				CA52B11229BBB256008345E0 /* TransactionList */,
+			);
+			path = Features;
+			sourceTree = "<group>";
+		};
+		CA52B11229BBB256008345E0 /* TransactionList */ = {
+			isa = PBXGroup;
+			children = (
+				CA52B11629BBD0BE008345E0 /* ViewModel */,
+				CA52B11329BBB26A008345E0 /* Models */,
+			);
+			path = TransactionList;
+			sourceTree = "<group>";
+		};
+		CA52B11329BBB26A008345E0 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				CA52B11429BBCD4C008345E0 /* TransactionListResponseModel.swift */,
+				CA52B11B29BD5E5D008345E0 /* Transaction.swift */,
+				CA52B11D29BD5E75008345E0 /* TransactionType.swift */,
+				CA52B11F29BD5E9E008345E0 /* TransactionIcon.swift */,
+				CA52B12129BD5EBA008345E0 /* TransactionAmount.swift */,
+				CA52B12329BD5EF1008345E0 /* TransactionCurrency.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		CA52B11629BBD0BE008345E0 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				CA52B11729BBD541008345E0 /* TransactionListViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		CADE073D29BB9D9900E1044A = {
+			isa = PBXGroup;
+			children = (
+				CADE074829BB9D9900E1044A /* SwileTest */,
+				CADE075929BB9D9B00E1044A /* SwileTestTests */,
+				CADE076329BB9D9B00E1044A /* SwileTestUITests */,
+				CADE074729BB9D9900E1044A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		CADE074729BB9D9900E1044A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CADE074629BB9D9900E1044A /* SwileTest.app */,
+				CADE075629BB9D9B00E1044A /* SwileTestTests.xctest */,
+				CADE076029BB9D9B00E1044A /* SwileTestUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CADE074829BB9D9900E1044A /* SwileTest */ = {
+			isa = PBXGroup;
+			children = (
+				CA52B11129BBB24B008345E0 /* Features */,
+				CA52B0FE29BBA023008345E0 /* Network */,
+				CADE074929BB9D9900E1044A /* SwileTestApp.swift */,
+				CADE074B29BB9D9900E1044A /* ContentView.swift */,
+				CADE074D29BB9D9B00E1044A /* Assets.xcassets */,
+				CADE074F29BB9D9B00E1044A /* Preview Content */,
+			);
+			path = SwileTest;
+			sourceTree = "<group>";
+		};
+		CADE074F29BB9D9B00E1044A /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				CADE075029BB9D9B00E1044A /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		CADE075929BB9D9B00E1044A /* SwileTestTests */ = {
+			isa = PBXGroup;
+			children = (
+				CA52B10129BBA156008345E0 /* Network */,
+				CADE075A29BB9D9B00E1044A /* SwileTestTests.swift */,
+			);
+			path = SwileTestTests;
+			sourceTree = "<group>";
+		};
+		CADE076329BB9D9B00E1044A /* SwileTestUITests */ = {
+			isa = PBXGroup;
+			children = (
+				CADE076429BB9D9B00E1044A /* SwileTestUITests.swift */,
+				CADE076629BB9D9B00E1044A /* SwileTestUITestsLaunchTests.swift */,
+			);
+			path = SwileTestUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CADE074529BB9D9900E1044A /* SwileTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CADE076A29BB9D9B00E1044A /* Build configuration list for PBXNativeTarget "SwileTest" */;
+			buildPhases = (
+				CADE074229BB9D9900E1044A /* Sources */,
+				CADE074329BB9D9900E1044A /* Frameworks */,
+				CADE074429BB9D9900E1044A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwileTest;
+			productName = SwileTest;
+			productReference = CADE074629BB9D9900E1044A /* SwileTest.app */;
+			productType = "com.apple.product-type.application";
+		};
+		CADE075529BB9D9B00E1044A /* SwileTestTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CADE076D29BB9D9B00E1044A /* Build configuration list for PBXNativeTarget "SwileTestTests" */;
+			buildPhases = (
+				CADE075229BB9D9B00E1044A /* Sources */,
+				CADE075329BB9D9B00E1044A /* Frameworks */,
+				CADE075429BB9D9B00E1044A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CADE075829BB9D9B00E1044A /* PBXTargetDependency */,
+			);
+			name = SwileTestTests;
+			productName = SwileTestTests;
+			productReference = CADE075629BB9D9B00E1044A /* SwileTestTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		CADE075F29BB9D9B00E1044A /* SwileTestUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CADE077029BB9D9B00E1044A /* Build configuration list for PBXNativeTarget "SwileTestUITests" */;
+			buildPhases = (
+				CADE075C29BB9D9B00E1044A /* Sources */,
+				CADE075D29BB9D9B00E1044A /* Frameworks */,
+				CADE075E29BB9D9B00E1044A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CADE076229BB9D9B00E1044A /* PBXTargetDependency */,
+			);
+			name = SwileTestUITests;
+			productName = SwileTestUITests;
+			productReference = CADE076029BB9D9B00E1044A /* SwileTestUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CADE073E29BB9D9900E1044A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1400;
+				LastUpgradeCheck = 1400;
+				TargetAttributes = {
+					CADE074529BB9D9900E1044A = {
+						CreatedOnToolsVersion = 14.0;
+					};
+					CADE075529BB9D9B00E1044A = {
+						CreatedOnToolsVersion = 14.0;
+						TestTargetID = CADE074529BB9D9900E1044A;
+					};
+					CADE075F29BB9D9B00E1044A = {
+						CreatedOnToolsVersion = 14.0;
+						TestTargetID = CADE074529BB9D9900E1044A;
+					};
+				};
+			};
+			buildConfigurationList = CADE074129BB9D9900E1044A /* Build configuration list for PBXProject "SwileTest" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CADE073D29BB9D9900E1044A;
+			productRefGroup = CADE074729BB9D9900E1044A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CADE074529BB9D9900E1044A /* SwileTest */,
+				CADE075529BB9D9B00E1044A /* SwileTestTests */,
+				CADE075F29BB9D9B00E1044A /* SwileTestUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CADE074429BB9D9900E1044A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CADE075129BB9D9B00E1044A /* Preview Assets.xcassets in Resources */,
+				CADE074E29BB9D9B00E1044A /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CADE075429BB9D9B00E1044A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CADE075E29BB9D9B00E1044A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CADE074229BB9D9900E1044A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA52B12229BD5EBA008345E0 /* TransactionAmount.swift in Sources */,
+				CADE074C29BB9D9900E1044A /* ContentView.swift in Sources */,
+				CA52B10029BBA0B4008345E0 /* NetworkService.swift in Sources */,
+				CADE074A29BB9D9900E1044A /* SwileTestApp.swift in Sources */,
+				CA52B11029BBB225008345E0 /* Service.swift in Sources */,
+				CA52B10D29BBB1AE008345E0 /* ServiceProtocol.swift in Sources */,
+				CA52B12429BD5EF1008345E0 /* TransactionCurrency.swift in Sources */,
+				CA52B11829BBD541008345E0 /* TransactionListViewModel.swift in Sources */,
+				CA52B11E29BD5E75008345E0 /* TransactionType.swift in Sources */,
+				CA52B11A29BD59E3008345E0 /* Endpoints.swift in Sources */,
+				CA52B11529BBCD4C008345E0 /* TransactionListResponseModel.swift in Sources */,
+				CA52B11C29BD5E5D008345E0 /* Transaction.swift in Sources */,
+				CA52B12029BD5E9E008345E0 /* TransactionIcon.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CADE075229BB9D9B00E1044A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA52B10629BBA1B0008345E0 /* URLSessionMock.swift in Sources */,
+				CA52B10829BBA20B008345E0 /* URLSessionDataTaskMock.swift in Sources */,
+				CA52B10329BBA176008345E0 /* NetworkServiceTests.swift in Sources */,
+				CADE075B29BB9D9B00E1044A /* SwileTestTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CADE075C29BB9D9B00E1044A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CADE076529BB9D9B00E1044A /* SwileTestUITests.swift in Sources */,
+				CADE076729BB9D9B00E1044A /* SwileTestUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		CADE075829BB9D9B00E1044A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CADE074529BB9D9900E1044A /* SwileTest */;
+			targetProxy = CADE075729BB9D9B00E1044A /* PBXContainerItemProxy */;
+		};
+		CADE076229BB9D9B00E1044A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CADE074529BB9D9900E1044A /* SwileTest */;
+			targetProxy = CADE076129BB9D9B00E1044A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		CADE076829BB9D9B00E1044A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		CADE076929BB9D9B00E1044A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		CADE076B29BB9D9B00E1044A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"SwileTest/Preview Content\"";
+				DEVELOPMENT_TEAM = 7H2AHWG667;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mateuscampos.SwileTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CADE076C29BB9D9B00E1044A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"SwileTest/Preview Content\"";
+				DEVELOPMENT_TEAM = 7H2AHWG667;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mateuscampos.SwileTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		CADE076E29BB9D9B00E1044A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7H2AHWG667;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mateuscampos.SwileTestTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SwileTest.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/SwileTest";
+			};
+			name = Debug;
+		};
+		CADE076F29BB9D9B00E1044A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7H2AHWG667;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mateuscampos.SwileTestTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SwileTest.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/SwileTest";
+			};
+			name = Release;
+		};
+		CADE077129BB9D9B00E1044A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7H2AHWG667;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mateuscampos.SwileTestUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SwileTest;
+			};
+			name = Debug;
+		};
+		CADE077229BB9D9B00E1044A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7H2AHWG667;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mateuscampos.SwileTestUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SwileTest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CADE074129BB9D9900E1044A /* Build configuration list for PBXProject "SwileTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CADE076829BB9D9B00E1044A /* Debug */,
+				CADE076929BB9D9B00E1044A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CADE076A29BB9D9B00E1044A /* Build configuration list for PBXNativeTarget "SwileTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CADE076B29BB9D9B00E1044A /* Debug */,
+				CADE076C29BB9D9B00E1044A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CADE076D29BB9D9B00E1044A /* Build configuration list for PBXNativeTarget "SwileTestTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CADE076E29BB9D9B00E1044A /* Debug */,
+				CADE076F29BB9D9B00E1044A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CADE077029BB9D9B00E1044A /* Build configuration list for PBXNativeTarget "SwileTestUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CADE077129BB9D9B00E1044A /* Debug */,
+				CADE077229BB9D9B00E1044A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CADE073E29BB9D9900E1044A /* Project object */;
+}

--- a/SwileTest/SwileTest.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SwileTest/SwileTest.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SwileTest/SwileTest.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SwileTest/SwileTest.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SwileTest/SwileTest.xcodeproj/xcshareddata/xcschemes/SwileTest.xcscheme
+++ b/SwileTest/SwileTest.xcodeproj/xcshareddata/xcschemes/SwileTest.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CADE074529BB9D9900E1044A"
+               BuildableName = "SwileTest.app"
+               BlueprintName = "SwileTest"
+               ReferencedContainer = "container:SwileTest.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CADE075529BB9D9B00E1044A"
+               BuildableName = "SwileTestTests.xctest"
+               BlueprintName = "SwileTestTests"
+               ReferencedContainer = "container:SwileTest.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CADE075F29BB9D9B00E1044A"
+               BuildableName = "SwileTestUITests.xctest"
+               BlueprintName = "SwileTestUITests"
+               ReferencedContainer = "container:SwileTest.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CADE074529BB9D9900E1044A"
+            BuildableName = "SwileTest.app"
+            BlueprintName = "SwileTest"
+            ReferencedContainer = "container:SwileTest.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CADE074529BB9D9900E1044A"
+            BuildableName = "SwileTest.app"
+            BlueprintName = "SwileTest"
+            ReferencedContainer = "container:SwileTest.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwileTest/SwileTest/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SwileTest/SwileTest/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwileTest/SwileTest/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SwileTest/SwileTest/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwileTest/SwileTest/Assets.xcassets/Contents.json
+++ b/SwileTest/SwileTest/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwileTest/SwileTest/ContentView.swift
+++ b/SwileTest/SwileTest/ContentView.swift
@@ -2,7 +2,7 @@
 //  ContentView.swift
 //  SwileTest
 //
-//  Created by guru on 10/03/23.
+//  Created by Mateus de Campos on 10/03/23.
 //
 
 import SwiftUI

--- a/SwileTest/SwileTest/ContentView.swift
+++ b/SwileTest/SwileTest/ContentView.swift
@@ -1,0 +1,28 @@
+//
+//  ContentView.swift
+//  SwileTest
+//
+//  Created by guru on 10/03/23.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var viewModel: TransactionListViewModel = TransactionListViewModel()
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundColor(.accentColor)
+            Text("Hello, world!")
+        }
+        .padding()
+        .onAppear(perform: viewModel.fetch)
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/SwileTest/SwileTest/Features/TransactionList/Models/Transaction.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/Models/Transaction.swift
@@ -1,0 +1,28 @@
+//
+//  Transaction.swift
+//  SwileTest
+//
+//  Created by guru on 11/03/23.
+//
+
+import Foundation
+
+struct Transaction: Codable {
+    let name: String
+    let type: TransactionType
+    let date: String
+    let message: String?
+    let amount: TransactionAmount
+    let smallIcon: TransactionIcon?
+    let largeIcon: TransactionIcon?
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case type
+        case date
+        case message
+        case amount
+        case smallIcon = "small_icon"
+        case largeIcon = "large_icon"
+    }
+}

--- a/SwileTest/SwileTest/Features/TransactionList/Models/Transaction.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/Models/Transaction.swift
@@ -2,7 +2,7 @@
 //  Transaction.swift
 //  SwileTest
 //
-//  Created by guru on 11/03/23.
+//  Created by Mateus de Campos on 11/03/23.
 //
 
 import Foundation

--- a/SwileTest/SwileTest/Features/TransactionList/Models/TransactionAmount.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/Models/TransactionAmount.swift
@@ -2,7 +2,7 @@
 //  TransactionAmount.swift
 //  SwileTest
 //
-//  Created by guru on 11/03/23.
+//  Created by Mateus de Campos on 11/03/23.
 //
 
 import Foundation

--- a/SwileTest/SwileTest/Features/TransactionList/Models/TransactionAmount.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/Models/TransactionAmount.swift
@@ -1,0 +1,13 @@
+//
+//  TransactionAmount.swift
+//  SwileTest
+//
+//  Created by guru on 11/03/23.
+//
+
+import Foundation
+
+struct TransactionAmount: Codable {
+    let value: Double
+    let currency: TransactionCurrency
+}

--- a/SwileTest/SwileTest/Features/TransactionList/Models/TransactionCurrency.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/Models/TransactionCurrency.swift
@@ -2,7 +2,7 @@
 //  TransactionCurrency.swift
 //  SwileTest
 //
-//  Created by guru on 11/03/23.
+//  Created by Mateus de Campos on 11/03/23.
 //
 
 import Foundation

--- a/SwileTest/SwileTest/Features/TransactionList/Models/TransactionCurrency.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/Models/TransactionCurrency.swift
@@ -1,0 +1,20 @@
+//
+//  TransactionCurrency.swift
+//  SwileTest
+//
+//  Created by guru on 11/03/23.
+//
+
+import Foundation
+
+struct TransactionCurrency: Codable {
+    let iso3: String
+    let symbol: String
+    let title: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case iso3 = "iso_3"
+        case symbol
+        case title
+    }
+}

--- a/SwileTest/SwileTest/Features/TransactionList/Models/TransactionIcon.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/Models/TransactionIcon.swift
@@ -1,0 +1,13 @@
+//
+//  Icon.swift
+//  SwileTest
+//
+//  Created by guru on 11/03/23.
+//
+
+import Foundation
+
+struct TransactionIcon: Codable {
+    let url: URL?
+    let category: String
+}

--- a/SwileTest/SwileTest/Features/TransactionList/Models/TransactionIcon.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/Models/TransactionIcon.swift
@@ -2,7 +2,7 @@
 //  Icon.swift
 //  SwileTest
 //
-//  Created by guru on 11/03/23.
+//  Created by Mateus de Campos on 11/03/23.
 //
 
 import Foundation

--- a/SwileTest/SwileTest/Features/TransactionList/Models/TransactionListResponseModel.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/Models/TransactionListResponseModel.swift
@@ -1,0 +1,12 @@
+//
+//  TransactionListResponseModel.swift
+//  SwileTest
+//
+//  Created by guru on 10/03/23.
+//
+
+import Foundation
+
+struct TransactionListResponseModel: Codable {
+    let transactions: [Transaction]
+}

--- a/SwileTest/SwileTest/Features/TransactionList/Models/TransactionListResponseModel.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/Models/TransactionListResponseModel.swift
@@ -2,7 +2,7 @@
 //  TransactionListResponseModel.swift
 //  SwileTest
 //
-//  Created by guru on 10/03/23.
+//  Created by Mateus de Campos on 10/03/23.
 //
 
 import Foundation

--- a/SwileTest/SwileTest/Features/TransactionList/Models/TransactionType.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/Models/TransactionType.swift
@@ -2,7 +2,7 @@
 //  TransactionType.swift
 //  SwileTest
 //
-//  Created by guru on 11/03/23.
+//  Created by Mateus de Campos on 11/03/23.
 //
 
 import Foundation

--- a/SwileTest/SwileTest/Features/TransactionList/Models/TransactionType.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/Models/TransactionType.swift
@@ -1,0 +1,16 @@
+//
+//  TransactionType.swift
+//  SwileTest
+//
+//  Created by guru on 11/03/23.
+//
+
+import Foundation
+
+enum TransactionType: String, Codable {
+    case donation
+    case mealVoucher = "meal_voucher"
+    case gift
+    case mobility
+    case payment
+}

--- a/SwileTest/SwileTest/Features/TransactionList/ViewModel/TransactionListViewModel.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/ViewModel/TransactionListViewModel.swift
@@ -1,0 +1,24 @@
+//
+//  TransactionListViewModel.swift
+//  SwileTest
+//
+//  Created by guru on 10/03/23.
+//
+
+import Foundation
+
+class TransactionListViewModel {
+    
+    func fetch() {
+        let transactionListService = Service<TransactionListResponseModel>(url: Endpoint.transactionList.url(),
+                                                                           method: .get) { result in
+            switch result {
+            case .success(let responseModel):
+                print("Transactions: \(responseModel.transactions)")
+            case .failure(let error):
+                print("Error fetching transactions: \(error.localizedDescription)")
+            }
+        }
+        transactionListService.start()
+    }
+}

--- a/SwileTest/SwileTest/Features/TransactionList/ViewModel/TransactionListViewModel.swift
+++ b/SwileTest/SwileTest/Features/TransactionList/ViewModel/TransactionListViewModel.swift
@@ -2,7 +2,7 @@
 //  TransactionListViewModel.swift
 //  SwileTest
 //
-//  Created by guru on 10/03/23.
+//  Created by Mateus de Campos on 10/03/23.
 //
 
 import Foundation

--- a/SwileTest/SwileTest/Network/Endpoints.swift
+++ b/SwileTest/SwileTest/Network/Endpoints.swift
@@ -1,0 +1,21 @@
+//
+//  Endpoints.swift
+//  SwileTest
+//
+//  Created by guru on 11/03/23.
+//
+
+import Foundation
+
+enum Endpoint: String {
+    static let baseUrl = "https://gist.githubusercontent.com"
+    case transactionList =
+            "/Aurazion/365d587f5917d1478bf03bacabdc69f3/raw/3c92b70e1dc808c8be822698f1cbff6c95ba3ad3/transactions.json"
+
+    func url() -> URL {
+        guard let url = URL(string: Endpoint.baseUrl + self.rawValue) else {
+            fatalError("Could not get base url")
+        }
+        return url
+    }
+}

--- a/SwileTest/SwileTest/Network/Endpoints.swift
+++ b/SwileTest/SwileTest/Network/Endpoints.swift
@@ -2,7 +2,7 @@
 //  Endpoints.swift
 //  SwileTest
 //
-//  Created by guru on 11/03/23.
+//  Created by Mateus de Campos on 11/03/23.
 //
 
 import Foundation

--- a/SwileTest/SwileTest/Network/NetworkService.swift
+++ b/SwileTest/SwileTest/Network/NetworkService.swift
@@ -2,7 +2,7 @@
 //  NetworkService.swift
 //  SwileTest
 //
-//  Created by guru on 10/03/23.
+//  Created by Mateus de Campos on 10/03/23.
 //
 
 import Foundation

--- a/SwileTest/SwileTest/Network/NetworkService.swift
+++ b/SwileTest/SwileTest/Network/NetworkService.swift
@@ -1,0 +1,85 @@
+//
+//  NetworkService.swift
+//  SwileTest
+//
+//  Created by guru on 10/03/23.
+//
+
+import Foundation
+
+enum HTTPMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case patch = "PATCH"
+    case delete = "DELETE"
+}
+
+protocol URLSessionProtocol {
+    func dataTask(with request: URLRequest,
+                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
+}
+
+protocol URLSessionDataTaskProtocol {
+    func resume()
+}
+
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
+
+extension URLSession: URLSessionProtocol {
+    func dataTask(with request: URLRequest,
+                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
+        return dataTask(with: request,
+                        completionHandler: completionHandler) as URLSessionDataTaskProtocol
+    }
+}
+
+typealias NetworkServiceCompletion = (Result<Data, Error>) -> Void
+
+protocol NetworkServiceProtocol {
+    func request(url: URL,
+                 method: HTTPMethod,
+                 parameters: [String: Any]?,
+                 headers: [String: String]?,
+                 completion: @escaping (Result<Data, Error>) -> Void)
+}
+
+class NetworkService: NetworkServiceProtocol {
+    private let session: URLSessionProtocol
+    
+    init(session: URLSessionProtocol = URLSession.shared) {
+        self.session = session
+    }
+    
+    func request(url: URL,
+                 method: HTTPMethod,
+                 parameters: [String: Any]? = nil,
+                 headers: [String: String]? = nil,
+                 completion: @escaping (Result<Data, Error>) -> Void) {
+        var request = URLRequest(url: url)
+        request.httpMethod = method.rawValue
+        if let headers = headers {
+            for (key, value) in headers {
+                request.addValue(value, forHTTPHeaderField: key)
+            }
+        }
+        if let parameters = parameters {
+            let jsonData = try? JSONSerialization.data(withJSONObject: parameters)
+            request.httpBody = jsonData
+        }
+        let task = session.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            guard let data = data else {
+                completion(.failure(NSError(domain: "",
+                                            code: -1,
+                                            userInfo: [NSLocalizedDescriptionKey: "No data received"])))
+                return
+            }
+            completion(.success(data))
+        }
+        task.resume()
+    }
+}

--- a/SwileTest/SwileTest/Network/Service.swift
+++ b/SwileTest/SwileTest/Network/Service.swift
@@ -1,0 +1,51 @@
+//
+//  TransactionListService.swift
+//  SwileTest
+//
+//  Created by guru on 10/03/23.
+//
+
+import Foundation
+
+class Service<T: Decodable>: ServiceProtocol {
+
+    var networkService: NetworkServiceProtocol
+    var url: URL
+    var method: HTTPMethod
+    var parameters: [String : Any]?
+    var headers: [String : String]?
+    var completion: ((Result<T, Error>) -> Void)?
+
+    init(networkService: NetworkServiceProtocol = NetworkService(),
+         url: URL,
+         method: HTTPMethod,
+         parameters: [String : Any]? = nil,
+         headers: [String : String]? = nil,
+         completion: ((Result<T, Error>) -> Void)? = nil) {
+        self.networkService = networkService
+        self.url = url
+        self.method = method
+        self.parameters = parameters
+        self.headers = headers
+        self.completion = completion
+    }
+
+    func start() {
+        networkService.request(url: url,
+                               method: method,
+                               parameters: parameters,
+                               headers: headers) { result in
+            switch result {
+            case .success(let data):
+                do {
+                    let decodedData = try JSONDecoder().decode(T.self, from: data)
+                    self.completion?(.success(decodedData))
+                } catch let error {
+                    self.completion?(.failure(error))
+                }
+            case .failure(let error):
+                self.completion?(.failure(error))
+            }
+        }
+    }
+}

--- a/SwileTest/SwileTest/Network/Service.swift
+++ b/SwileTest/SwileTest/Network/Service.swift
@@ -2,7 +2,7 @@
 //  TransactionListService.swift
 //  SwileTest
 //
-//  Created by guru on 10/03/23.
+//  Created by Mateus de Campos on 10/03/23.
 //
 
 import Foundation

--- a/SwileTest/SwileTest/Network/ServiceProtocol.swift
+++ b/SwileTest/SwileTest/Network/ServiceProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  ServiceProtocol.swift
+//  SwileTest
+//
+//  Created by guru on 10/03/23.
+//
+
+import Foundation
+
+protocol ServiceProtocol {
+    associatedtype T: Decodable
+    var networkService: NetworkServiceProtocol { get set }
+    var url: URL { get set }
+    var method: HTTPMethod { get set }
+    var parameters: [String: Any]? { get set }
+    var headers: [String: String]? { get set }
+    var completion: ((Result<T, Error>) -> Void)? { get set }
+    func start()
+}

--- a/SwileTest/SwileTest/Network/ServiceProtocol.swift
+++ b/SwileTest/SwileTest/Network/ServiceProtocol.swift
@@ -2,7 +2,7 @@
 //  ServiceProtocol.swift
 //  SwileTest
 //
-//  Created by guru on 10/03/23.
+//  Created by Mateus de Campos on 10/03/23.
 //
 
 import Foundation

--- a/SwileTest/SwileTest/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/SwileTest/SwileTest/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwileTest/SwileTest/SwileTestApp.swift
+++ b/SwileTest/SwileTest/SwileTestApp.swift
@@ -2,7 +2,7 @@
 //  SwileTestApp.swift
 //  SwileTest
 //
-//  Created by guru on 10/03/23.
+//  Created by Mateus de Campos on 10/03/23.
 //
 
 import SwiftUI

--- a/SwileTest/SwileTest/SwileTestApp.swift
+++ b/SwileTest/SwileTest/SwileTestApp.swift
@@ -1,0 +1,17 @@
+//
+//  SwileTestApp.swift
+//  SwileTest
+//
+//  Created by guru on 10/03/23.
+//
+
+import SwiftUI
+
+@main
+struct SwileTestApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/SwileTest/SwileTestTests/Network/Mocks/URLSessionDataTaskMock.swift
+++ b/SwileTest/SwileTestTests/Network/Mocks/URLSessionDataTaskMock.swift
@@ -2,7 +2,7 @@
 //  URLSessionDataTaskMock.swift
 //  SwileTestTests
 //
-//  Created by guru on 10/03/23.
+//  Created by Mateus de Campos on 10/03/23.
 //
 
 import Foundation

--- a/SwileTest/SwileTestTests/Network/Mocks/URLSessionDataTaskMock.swift
+++ b/SwileTest/SwileTestTests/Network/Mocks/URLSessionDataTaskMock.swift
@@ -1,0 +1,17 @@
+//
+//  URLSessionDataTaskMock.swift
+//  SwileTestTests
+//
+//  Created by guru on 10/03/23.
+//
+
+import Foundation
+@testable import SwileTest
+
+class URLSessionDataTaskMock: URLSessionDataTaskProtocol {
+    var resumeWasCalled = false
+    
+    func resume() {
+        resumeWasCalled = true
+    }
+}

--- a/SwileTest/SwileTestTests/Network/Mocks/URLSessionMock.swift
+++ b/SwileTest/SwileTestTests/Network/Mocks/URLSessionMock.swift
@@ -2,7 +2,7 @@
 //  URLSessionMock.swift
 //  SwileTestTests
 //
-//  Created by guru on 10/03/23.
+//  Created by Mateus de Campos on 10/03/23.
 //
 
 import Foundation

--- a/SwileTest/SwileTestTests/Network/Mocks/URLSessionMock.swift
+++ b/SwileTest/SwileTestTests/Network/Mocks/URLSessionMock.swift
@@ -1,0 +1,23 @@
+//
+//  URLSessionMock.swift
+//  SwileTestTests
+//
+//  Created by guru on 10/03/23.
+//
+
+import Foundation
+@testable import SwileTest
+
+class URLSessionMock: URLSessionProtocol {
+    var nextDataTask = URLSessionDataTaskMock()
+    var lastRequest: URLRequest?
+    var nextData: Data?
+    var nextError: Error?
+    
+    func dataTask(with request: URLRequest,
+                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
+        lastRequest = request
+        completionHandler(nextData, nil, nextError)
+        return nextDataTask
+    }
+}

--- a/SwileTest/SwileTestTests/Network/NetworkServiceTests.swift
+++ b/SwileTest/SwileTestTests/Network/NetworkServiceTests.swift
@@ -2,7 +2,7 @@
 //  NetworkServiceTests.swift
 //  SwileTestTests
 //
-//  Created by guru on 10/03/23.
+//  Created by Mateus de Campos on 10/03/23.
 //
 
 import XCTest

--- a/SwileTest/SwileTestTests/Network/NetworkServiceTests.swift
+++ b/SwileTest/SwileTestTests/Network/NetworkServiceTests.swift
@@ -1,0 +1,90 @@
+//
+//  NetworkServiceTests.swift
+//  SwileTestTests
+//
+//  Created by guru on 10/03/23.
+//
+
+import XCTest
+import Foundation
+@testable import SwileTest
+
+class NetworkServiceTests: XCTestCase {
+    var sut: NetworkService!
+    var sessionMock: URLSessionMock!
+    
+    override func setUpWithError() throws {
+        sessionMock = URLSessionMock()
+        sut = NetworkService(session: sessionMock)
+    }
+    
+    override func tearDownWithError() throws {
+        sut = nil
+        sessionMock = nil
+    }
+    
+    func testGetRequest() {
+        let url = URL(string: "https://mock.com")!
+        let expectation = XCTestExpectation(description: "Completion")
+        sessionMock.nextData = Data()
+        sessionMock.nextError = nil
+        sut.request(url: url, method: .get) { result in
+            XCTAssertEqual(self.sessionMock.lastRequest?.url, url)
+            XCTAssertEqual(self.sessionMock.lastRequest?.httpMethod, "GET")
+            XCTAssertNotNil(self.sessionMock.nextDataTask)
+            switch result {
+            case .success(let data):
+                XCTAssertEqual(data, Data())
+            case .failure(_):
+                XCTFail("Should not fail")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(self.sessionMock.nextDataTask.resumeWasCalled)
+    }
+    
+    func testPostRequest() {
+        let url = URL(string: "https://mock.com")!
+        let expectation = XCTestExpectation(description: "Completion")
+        let parameters = ["foo": "bar"]
+        sessionMock.nextData = Data()
+        sessionMock.nextError = nil
+        sut.request(url: url, method: .post, parameters: parameters) { result in
+            XCTAssertEqual(self.sessionMock.lastRequest?.url, url)
+            XCTAssertEqual(self.sessionMock.lastRequest?.httpMethod, "POST")
+            XCTAssertNotNil(self.sessionMock.nextDataTask)
+            switch result {
+            case .success(let data):
+                XCTAssertEqual(data, Data())
+            case .failure(_):
+                XCTFail("Should not fail")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(self.sessionMock.lastRequest?.httpBody, try? JSONSerialization.data(withJSONObject: parameters))
+        XCTAssertTrue(self.sessionMock.nextDataTask.resumeWasCalled)
+    }
+    
+    func testError() {
+        let url = URL(string: "https://mock.com")!
+        let expectation = XCTestExpectation(description: "Completion")
+        sessionMock.nextData = nil
+        sessionMock.nextError = NSError(domain: "", code: -1, userInfo: nil)
+        sut.request(url: url, method: .get) { result in
+            XCTAssertEqual(self.sessionMock.lastRequest?.url, url)
+            XCTAssertEqual(self.sessionMock.lastRequest?.httpMethod, "GET")
+            XCTAssertNotNil(self.sessionMock.nextDataTask)
+            switch result {
+            case .success(_):
+                XCTFail("Should not succeed")
+            case .failure(let error):
+                XCTAssertNotNil(error)
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(self.sessionMock.nextDataTask.resumeWasCalled)
+    }
+}

--- a/SwileTest/SwileTestTests/SwileTestTests.swift
+++ b/SwileTest/SwileTestTests/SwileTestTests.swift
@@ -2,7 +2,7 @@
 //  SwileTestTests.swift
 //  SwileTestTests
 //
-//  Created by guru on 10/03/23.
+//  Created by Mateus de Campos on 10/03/23.
 //
 
 import XCTest

--- a/SwileTest/SwileTestTests/SwileTestTests.swift
+++ b/SwileTest/SwileTestTests/SwileTestTests.swift
@@ -1,0 +1,36 @@
+//
+//  SwileTestTests.swift
+//  SwileTestTests
+//
+//  Created by guru on 10/03/23.
+//
+
+import XCTest
+@testable import SwileTest
+
+final class SwileTestTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/SwileTest/SwileTestUITests/SwileTestUITests.swift
+++ b/SwileTest/SwileTestUITests/SwileTestUITests.swift
@@ -1,0 +1,41 @@
+//
+//  SwileTestUITests.swift
+//  SwileTestUITests
+//
+//  Created by guru on 10/03/23.
+//
+
+import XCTest
+
+final class SwileTestUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/SwileTest/SwileTestUITests/SwileTestUITests.swift
+++ b/SwileTest/SwileTestUITests/SwileTestUITests.swift
@@ -2,7 +2,7 @@
 //  SwileTestUITests.swift
 //  SwileTestUITests
 //
-//  Created by guru on 10/03/23.
+//  Created by Mateus de Campos on 10/03/23.
 //
 
 import XCTest

--- a/SwileTest/SwileTestUITests/SwileTestUITestsLaunchTests.swift
+++ b/SwileTest/SwileTestUITests/SwileTestUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  SwileTestUITestsLaunchTests.swift
+//  SwileTestUITests
+//
+//  Created by guru on 10/03/23.
+//
+
+import XCTest
+
+final class SwileTestUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/SwileTest/SwileTestUITests/SwileTestUITestsLaunchTests.swift
+++ b/SwileTest/SwileTestUITests/SwileTestUITestsLaunchTests.swift
@@ -2,7 +2,7 @@
 //  SwileTestUITestsLaunchTests.swift
 //  SwileTestUITests
 //
-//  Created by guru on 10/03/23.
+//  Created by Mateus de Campos on 10/03/23.
 //
 
 import XCTest


### PR DESCRIPTION
The changes in this pull request add new functionality to the SwileTest app. Specifically, a network layer to communicate within the internet, a new `Transaction` model has been created, along with related models for `TransactionAmount`, `TransactionCurrency`, and `TransactionIcon`. These models parse JSON data retrieved from a remote API endpoint. Additionally, a new `TransactionListViewModel` has been created to handle network requests and the parsing of transaction data. Finally, several updates have been made to the existing code to use the new models and view models.